### PR TITLE
docs: fix README inconsistencies and add controller comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ From zero to GitOps in one command — opinionated CLI to bootstrap a production
 - [CLI Interface](#cli-interface)
 - [Design Decisions](#design-decisions)
   - [Why App of Apps (ArgoCD) / Kustomization chain (Flux)?](#why-app-of-apps-argocd--kustomization-chain-flux)
+  - [ArgoCD vs Flux: which one should I choose?](#argocd-vs-flux-which-one-should-i-choose)
   - [Why Kustomize as default (with Helm as option)?](#why-kustomize-as-default-with-helm-as-option)
   - [Why Sealed Secrets as default?](#why-sealed-secrets-as-default)
   - [Secrets management: scalability and limitations](#secrets-management-scalability-and-limitations)
@@ -76,7 +77,7 @@ sudo mv gostrap /usr/local/bin/
 ## Quick Start
 
 ```bash
-# 1. Bootstrap a GitOps repo + install ArgoCD on your cluster
+# 1. Bootstrap a GitOps repo + install the controller on your cluster
 gostrap init
 
 # 2. Add applications to the repo
@@ -152,11 +153,11 @@ Running `gostrap init` on a cluster produces:
 
 ### In the Cluster
 
-- GitOps controller installed and configured (ArgoCD by default, Flux as alternative)
+- GitOps controller installed and configured (ArgoCD or Flux CD — your choice)
 - Namespace structure for the controller and managed environments
 - RBAC for the GitOps controller (least privilege)
 - Secrets management (Sealed Secrets, External Secrets Operator, or SOPS with age)
-- Optional: Ingress for the ArgoCD UI with TLS
+- Optional: Ingress for the controller UI with TLS (ArgoCD)
 
 ### In the Git Repository
 
@@ -453,55 +454,6 @@ policies:
   engine: kyverno
 ```
 
-### Interactive Wizard Flow (Planned)
-
-```
-$ gostrap init
-
-  ╭─────────────────────────────────────────╮
-  │            gostrap v0.3.0               │
-  │   From zero to GitOps in one command    │
-  ╰─────────────────────────────────────────╯
-
-  ? Select GitOps controller:
-    ❯ ArgoCD (recommended)
-      Flux CD
-
-  ? ArgoCD version: (2.13.1)
-
-  ? Select secrets management:
-    ❯ Sealed Secrets (simple, self-contained)
-      External Secrets Operator (AWS SM, Vault, etc.)
-      SOPS (git-native encryption)
-
-  ? Application manifest format:
-    ❯ Kustomize (plain YAML with overlays)
-      Helm (chart with values per environment)
-
-  ? Environments to create: (dev, staging, production)
-
-  ? Scaffold an example application? (Y/n)
-
-  ? Target repo path: (./gitops-repo)
-
-  ? Cluster context: (current: prod-eu-west-1)
-
-  ⠸ Installing ArgoCD v2.13.1...          ✓
-  ⠸ Setting up Sealed Secrets...          ✓
-  ⠸ Generating repo structure...          ✓
-  ⠸ Creating example application...       ✓
-  ⠸ Generating documentation...           ✓
-  ⠸ Verifying cluster health...           ✓
-
-  ✓ GitOps bootstrap complete!
-
-  Next steps:
-    1. cd ./gitops-repo && git init && git add -A && git commit -m "feat: initial gitops structure"
-    2. Push to your Git provider
-    3. ArgoCD UI: https://argocd.internal.company.com
-    4. Read docs/ADDING-AN-APP.md to onboard your first real application
-```
-
 ## Design Decisions
 
 ### Why App of Apps (ArgoCD) / Kustomization chain (Flux)?
@@ -510,6 +462,24 @@ For **ArgoCD**, gostrap uses the [App of Apps pattern](https://argo-cd.readthedo
 - Single entry point for the entire cluster state.
 - Self-service: dev teams add a YAML to `apps/` to onboard.
 - Declarative: the list of applications is version-controlled.
+
+### ArgoCD vs Flux: which one should I choose?
+
+gostrap supports both controllers as first-class options. ArgoCD is marked as "recommended" in the wizard because it offers a gentler onboarding experience, but Flux is equally well supported.
+
+|  | **ArgoCD** | **Flux CD** |
+|---|---|---|
+| **CNCF status** | Graduated | Graduated |
+| **Web UI** | Built-in dashboard with sync status, diff viewer, and rollback | No native UI (add [Weave GitOps](https://github.com/weaveworks/weave-gitops) or similar) |
+| **Mental model** | One `Application` CRD = one deployed app, visual feedback | Modular controllers (source, kustomize, helm, notification) composed via CRDs |
+| **RBAC** | Granular: SSO/OIDC, projects, per-repo/per-cluster policies | Delegates to Kubernetes RBAC; multi-tenancy via namespaced `Kustomization` |
+| **Helm support** | Renders charts server-side; supports `values.yaml` overlays | `HelmRelease` CRD with dependency management and automated upgrades |
+| **Multi-cluster** | Centralized hub managing remote clusters from a single UI | Agent-per-cluster (decentralized); each cluster reconciles independently |
+| **Notifications** | Built-in notification engine (Slack, webhook, GitHub) | Separate `notification-controller` with provider CRDs |
+| **Image automation** | Separate [Image Updater](https://argocd-image-updater.readthedocs.io/) project | Built-in `image-reflector-controller` + `image-automation-controller` |
+| **Best for** | Teams wanting visual operations, onboarding newcomers to GitOps | Teams preferring pure Git workflows, no UI dependency, or advanced automation |
+
+**TL;DR**: Choose **ArgoCD** if you value a web UI and visual feedback. Choose **Flux** if you prefer everything-as-code with no UI dependency and want tighter integration with Helm and image automation.
 
 ### Why Kustomize as default (with Helm as option)?
 


### PR DESCRIPTION
## Summary

- Neutralized Quick Start comment to not mention ArgoCD explicitly (`install the controller` instead of `install ArgoCD`)
- Neutralized "What It Sets Up" section for balanced controller framing (`ArgoCD or Flux CD — your choice`)
- Removed redundant "Interactive Wizard Flow (Planned)" section — its content was already covered in the Quick Start section and the "(Planned)" label was outdated
- Added ArgoCD vs Flux comparison table under Design Decisions (incorporates content from #49)
- Updated Table of Contents with the new comparison section

Supersedes #49.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify no broken ToC links
- [ ] Verify ArgoCD vs Flux comparison table displays correctly